### PR TITLE
:bug: clicking suggestion didn't fill out the search - fixed

### DIFF
--- a/models/dbHelpers.js
+++ b/models/dbHelpers.js
@@ -7,6 +7,6 @@ module.exports = {
 }
 
 async function fetchWord (word) {
-    return await db.select('bare','accented').from('words').where('bare','like',`${word}%`).limit(10)
+    return await db.select('bare','accented','id').from('words').where('bare','like',`${word}%`).limit(10)
 }
 

--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -65,7 +65,7 @@ const SearchBar = (props) => {
                       searchResults.map((result)=>{
                           return <motion.li 
                                     onClick={()=>selectSuggestHandler(result.id)} 
-                                    key={result.bare}
+                                    key={result.id}
                                     whileHover={{ translateX: 5 }}
                                 >
                                     {result.accented}


### PR DESCRIPTION
Issue: Picked up on an issue whereby you clicked the autosuggestion and it just filled out the list with the first autosuggestion element and not the one you selected. 

Fix: I removed the id from the database which I was using to figure out which autosuggestion was clicked. Added it back to the db helper and the issue was fixed. 